### PR TITLE
Update glossary - added definition of 'index' (English).yml

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -5520,6 +5520,12 @@
       The factor that you purposely change or control in order to see what effect 
       it has on the [dependent variable](#dependent_variable).
 
+- slug: index
+  en:
+    term: "index"
+    def: >
+      Each of the elements of an array. Indexes represent the position by numerical representation.
+
 
 - slug: infinite_loop
   ref:


### PR DESCRIPTION
Added definition of 'index'

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- 

## Language: 

- 

## Terms defined:

- 
- 
- 
